### PR TITLE
Update and rename wsdd-0.8.ebuild to wsdd-0.8-r1.ebuild

### DIFF
--- a/net-misc/wsdd/wsdd-0.8-r1.ebuild
+++ b/net-misc/wsdd/wsdd-0.8-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{9,10,11,12} )
+PYTHON_COMPAT=( python3_{9,10,11,12,13} )
 PYTHON_REQ_USE="xml(+)"
 
 inherit python-r1 systemd


### PR DESCRIPTION
Added python 3.13 support. Have tested it on my local system and it seems good.

Note, might be a good idea to switch to `EAPI=8` for future compatibility. I don't think it would require any other changes to the ebuild.